### PR TITLE
Feature/customizable currency

### DIFF
--- a/config-example.yml
+++ b/config-example.yml
@@ -45,6 +45,8 @@ frontend:
   eth1Currency: 'EXM'
   eth1CurrencyName: 'Example'
   eth1CurrencyFormatDecimals: 5
+  eth1Label: "Eth1"
+  eth2Labal: "Eth2"
 
 # Indexer config
 indexer:

--- a/config-example.yml
+++ b/config-example.yml
@@ -43,6 +43,8 @@ frontend:
       password: "<emailpassword>"
   flashSecret: "" # Encryption secret for flash cookies
   eth1Currency: 'EXM'
+  eth1CurrencyName: 'Example'
+  eth1CurrencyFormatDecimals: 5
 
 # Indexer config
 indexer:

--- a/config-example.yml
+++ b/config-example.yml
@@ -42,6 +42,7 @@ frontend:
       user: "<emailuser>"
       password: "<emailpassword>"
   flashSecret: "" # Encryption secret for flash cookies
+  eth1Currency: 'EXM'
 
 # Indexer config
 indexer:

--- a/config-example.yml
+++ b/config-example.yml
@@ -46,7 +46,7 @@ frontend:
   eth1CurrencyName: 'Example'
   eth1CurrencyFormatDecimals: 5
   eth1Label: "Eth1"
-  eth2Labal: "Eth2"
+  eth2Label: "Eth2"
 
 # Indexer config
 indexer:

--- a/handlers/common.go
+++ b/handlers/common.go
@@ -172,7 +172,8 @@ func GetCurrency(r *http.Request) string {
 		return cookie.Value
 	}
 
-	return "ETH"
+	return utils.Config.Frontend.Eth1Currency
+	// return "ETH"
 }
 
 func GetCurrencySymbol(r *http.Request) string {

--- a/handlers/pageData.go
+++ b/handlers/pageData.go
@@ -63,6 +63,8 @@ func InitPageData(w http.ResponseWriter, r *http.Request, active, path, title st
 		ClientsUpdated:        ethclients.ClientsUpdated(),
 		Phase0:                utils.Config.Chain.Phase0,
 		Lang:                  "en-US",
+		DefaultCurrency:       utils.Config.Frontend.Eth1Currency,
+		DefaultCurrencyName:   utils.Config.Frontend.Eth1CurrencyName,
 	}
 	data.EthPrice = price.GetEthPrice(data.Currency)
 	data.ExchangeRate = price.GetEthPrice(data.Currency)

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -58,6 +58,10 @@ func Validator(w http.ResponseWriter, r *http.Request) {
 	validatorPageData.NetworkStats = services.LatestIndexPageData()
 	validatorPageData.User = data.User
 
+	// Set 'Eth1' and 'Eth2' networks labels
+	validatorPageData.Eth1Label = utils.Config.Frontend.Eth1Label
+	validatorPageData.Eth2Label = utils.Config.Frontend.Eth2Label
+
 	validatorPageData.FlashMessage, err = utils.GetFlash(w, r, validatorEditFlash)
 	if err != nil {
 		logger.Errorf("error retrieving flashes for validator %v: %v", vars["index"], err)

--- a/handlers/validators_leaderboard.go
+++ b/handlers/validators_leaderboard.go
@@ -21,6 +21,11 @@ func ValidatorsLeaderboard(w http.ResponseWriter, r *http.Request) {
 	data := InitPageData(w, r, "validators", "/validators/leaderboard", "Validator Staking Leaderboard")
 	data.HeaderAd = true
 
+	pageData := &types.ValidatorsLeaderboardPageData{}
+	pageData.Currency = data.DefaultCurrency
+
+	data.Data = pageData
+
 	err := validatorsLeaderboardTemplate.ExecuteTemplate(w, "layout", data)
 
 	if err != nil {

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -258,10 +258,10 @@
                        <div id="currencyDropdown">{{.Currency}}</div>
                     </a>
                     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="currencyDropdown">
-                        <a tabindex="1" class="dropdown-item cursor-pointer" onClick="updateCurrency('ETH')">
-                            <img class="currency-flag-option" src="/img/ETH.svg">
-                            <span class="currency-name">Ether</span>
-                            ETH
+                        <a tabindex="1" class="dropdown-item cursor-pointer" onClick="updateCurrency('{{.DefaultCurrency}}')">
+                            <img class="currency-flag-option" src="/img/{{.DefaultCurrency}}.svg">
+                            <span class="currency-name">{{.DefaultCurrencyName}}</span>
+                            {{.DefaultCurrency}}
                         </a>
                         <a tabindex="1" class="dropdown-item cursor-pointer" onClick="updateCurrency('USD')">
                             <img class="currency-flag-option" src="/img/USD.svg">

--- a/templates/validator/overview.html
+++ b/templates/validator/overview.html
@@ -148,7 +148,7 @@
                       class="text-muted font-weight-lighter position-absolute"><small>Balance</small></span>
                 <div style="width: 8.32rem" class="d-flex flex-column">
                     <span style="font-weight: bold; font-size:18px;">{{formatCurrentBalance .CurrentBalance $.Currency }}</span>
-                    <span style="font-size: 0.8rem; color: gray">{{formatEffectiveBalance .EffectiveBalance "ETH" }} <span data-toggle="tooltip"
+                    <span style="font-size: 0.8rem; color: gray">{{formatEffectiveBalance .EffectiveBalance $.DefaultCurrency }} <span data-toggle="tooltip"
                                                                                     title="The effective balance is used to calculate the base rewards of a validator"><a
                                     class="no-highlight" href="https://kb.beaconcha.in/glossary#current-balance-and-effective-balance"><i
                                         class="far ml-1 fa-question-circle"></i></a></span></span>

--- a/templates/validator/tables.html
+++ b/templates/validator/tables.html
@@ -200,8 +200,8 @@
 {{define "validatorDepositsTable"}}
 {{ with .Data }}
     <div class="table-eth1">
-        <h4 class="my-3">Eth1 Deposits</h4>
-        <h6 class="">This table displays the deposits made to the Eth1 deposit contract.</h6>
+        <h4 class="my-3">{{ .Eth1Label }} Deposits</h4>
+        <h6 class="">This table displays the deposits made to the {{ .Eth1Label }} deposit contract.</h6>
         <div class="table-responsive card card-body p-0">
             <table class="table" style="margin-top: 0 !important" id="deposits-eth1-table" width="100%">
                 <thead>
@@ -233,7 +233,7 @@
         <i class="fas fa-arrow-down"></i>
     </div>
     <div class="table-eth2">
-        <h4 class="my-3">Eth2 Deposits</h4>
+        <h4 class="my-3">{{ .Eth2Label }} Deposits</h4>
         {{if not .Deposits.Eth2Deposits}}
             <h6 class="">No beacon chain deposits found for this validator. It takes <a href="https://kb.beaconcha.in/ethereum-2.0-and-depositing-process">around {{.InclusionDelay}} hours</a> for a deposit to be
                 processed by the beacon chain.</h6>

--- a/templates/validators_leaderboard.html
+++ b/templates/validators_leaderboard.html
@@ -35,7 +35,7 @@
                         targets: 3,
                         data: '3',
                         render: function (data, type, row, meta) {
-                            return (data / 10e8).toFixed(4) + ' ETH'
+                            return (data / 10e8).toFixed(4) + " STAKE"
                         },
                         "orderable": false
                     }

--- a/templates/validators_leaderboard.html
+++ b/templates/validators_leaderboard.html
@@ -35,7 +35,7 @@
                         targets: 3,
                         data: '3',
                         render: function (data, type, row, meta) {
-                            return (data / 10e8).toFixed(4) + " STAKE"
+                            return (data / 10e8).toFixed(4) + " {{ .Currency }}"
                         },
                         "orderable": false
                     }

--- a/types/config.go
+++ b/types/config.go
@@ -122,8 +122,10 @@ type Config struct {
 			Timestamp uint64 `yaml:"timestamp" envconfig:"FRONTEND_COUNTDOWN_TIMESTAMP"`
 			Info      string `yaml:"info" envconfig:"FRONTEND_COUNTDOWN_INFO"`
 		} `yaml:"countdown"`
-		Eth1ExplorerBase string `yaml:"eth1ExplorerBase" envconfig:"FRONTEND_ETH1_EXPLORER_BASE"`
-		Eth1Currency     string `yaml:"eth1Currency" envconfig:"FRONTEND_ETH1_CURRENCY"`
+		Eth1ExplorerBase           string `yaml:"eth1ExplorerBase" envconfig:"FRONTEND_ETH1_EXPLORER_BASE"`
+		Eth1Currency               string `yaml:"eth1Currency" envconfig:"FRONTEND_ETH1_CURRENCY"`
+		Eth1CurrencyName           string `yaml:"eth1CurrencyName" envconfig:"FRONTEND_ETH1_CURRENCY_NAME"`
+		Eth1CurrencyFormatDecimals int    `yaml:"eth1CurrencyFormatDecimals" envconfig:"FRONTEND_ETH1_CURRENCY_FORMAT_DECIMALS"`
 	} `yaml:"frontend"`
 	Metrics struct {
 		Enabled bool   `yaml:"enabled" envconfig:"METRICS_ENABLED"`

--- a/types/config.go
+++ b/types/config.go
@@ -123,6 +123,7 @@ type Config struct {
 			Info      string `yaml:"info" envconfig:"FRONTEND_COUNTDOWN_INFO"`
 		} `yaml:"countdown"`
 		Eth1ExplorerBase string `yaml:"eth1ExplorerBase" envconfig:"FRONTEND_ETH1_EXPLORER_BASE"`
+		Eth1Currency     string `yaml:"eth1Currency" envconfig:"FRONTEND_ETH1_CURRENCY"`
 	} `yaml:"frontend"`
 	Metrics struct {
 		Enabled bool   `yaml:"enabled" envconfig:"METRICS_ENABLED"`

--- a/types/config.go
+++ b/types/config.go
@@ -126,6 +126,8 @@ type Config struct {
 		Eth1Currency               string `yaml:"eth1Currency" envconfig:"FRONTEND_ETH1_CURRENCY"`
 		Eth1CurrencyName           string `yaml:"eth1CurrencyName" envconfig:"FRONTEND_ETH1_CURRENCY_NAME"`
 		Eth1CurrencyFormatDecimals int    `yaml:"eth1CurrencyFormatDecimals" envconfig:"FRONTEND_ETH1_CURRENCY_FORMAT_DECIMALS"`
+		Eth1Label                  string `yaml:"eth1Label" envconfig:"FRONTEND_ETH1_LABEL"`
+		Eth2Label                  string `yaml:"eth2Label" envconfig:"FRONTEND_ETH2_LABEL"`
 	} `yaml:"frontend"`
 	Metrics struct {
 		Enabled bool   `yaml:"enabled" envconfig:"METRICS_ENABLED"`

--- a/types/templates.go
+++ b/types/templates.go
@@ -327,6 +327,8 @@ type ValidatorPageData struct {
 	InclusionDelay                      int64
 	CurrentAttestationStreak            uint64
 	LongestAttestationStreak            uint64
+	Eth1Label                           string
+	Eth2Label                           string
 }
 
 type ValidatorStatsTablePageData struct {

--- a/types/templates.go
+++ b/types/templates.go
@@ -361,6 +361,10 @@ type ValidatorStatsTableRow struct {
 	DepositsAmount         sql.NullInt64 `db:"deposits_amount"`
 }
 
+type ValidatorsLeaderboardPageData struct {
+	Currency string
+}
+
 type ChartDataPoint struct {
 	X     float64 `json:"x"`
 	Y     float64 `json:"y"`

--- a/types/templates.go
+++ b/types/templates.go
@@ -56,6 +56,8 @@ type PageData struct {
 	IsUserClientUpdated   func(uint64) bool
 	Phase0                Phase0
 	Lang                  string
+	DefaultCurrency       string
+	DefaultCurrencyName   string
 }
 
 // Meta is a struct to hold metadata about the page

--- a/utils/format.go
+++ b/utils/format.go
@@ -124,7 +124,7 @@ func FormatBalanceGwei(balance *int64, currency string) template.HTML {
 // FormatBalanceChange will return a string for a balance change
 func FormatBalanceChange(balance *int64, currency string) template.HTML {
 	balanceF := float64(*balance) / float64(1e9)
-	if currency == "ETH" {
+	if currency == Config.Frontend.Eth1Currency {
 		if balance == nil {
 			return template.HTML("<span> 0.00000 " + currency + "</span>")
 		} else if *balance == 0 {
@@ -132,9 +132,9 @@ func FormatBalanceChange(balance *int64, currency string) template.HTML {
 		}
 
 		if balanceF < 0 {
-			return template.HTML(fmt.Sprintf("<span title=\"%.0f GWei\" data-toggle=\"tooltip\" class=\"text-danger\">%.5f ETH</span>", float64(*balance), balanceF))
+			return template.HTML(fmt.Sprintf("<span data-toggle=\"tooltip\" class=\"text-danger\">%.5f %s</span>", balanceF, currency))
 		}
-		return template.HTML(fmt.Sprintf("<span title=\"%.0f GWei\" data-toggle=\"tooltip\" class=\"text-success\">+%.5f ETH</span>", float64(*balance), balanceF))
+		return template.HTML(fmt.Sprintf("<span data-toggle=\"tooltip\" class=\"text-success\">+%.5f %s</span>", balanceF, currency))
 	} else {
 		if balance == nil {
 			return template.HTML("<span> 0.00" + currency + "</span>")
@@ -436,8 +436,8 @@ func FormatIncome(balanceInt int64, currency string) template.HTML {
 
 	decimals := "%.2f"
 
-	if currency == "ETH" {
-		decimals = "%.5f"
+	if currency == Config.Frontend.Eth1Currency {
+		decimals = fmt.Sprintf("%%.%df", Config.Frontend.Eth1CurrencyFormatDecimals)
 	}
 
 	rb := []rune(p.Sprintf(decimals, balance*exchangeRate))


### PR DESCRIPTION
The request adds a new configuration variable _eth1Currency_ where the name of the currency used in depositing may be placed. The work is still in progress. There are several changes occurring on different pages:

1. The currency name located near login becomes customizable (however, another problem arises with absent currency symbol image).
    ![image](https://user-images.githubusercontent.com/25086020/133080267-262bbaac-6dd0-4ccf-8184-3acc7cad30d6.png)

2. The staking token symbol in the validator page (`http://u.r.l./validator/{index}#deposits`) is as well changed on the configured value (although, it seems that some problems arise with "Validator history" block).
    ![image](https://user-images.githubusercontent.com/25086020/133081188-5a201312-6bcd-4880-8253-ef44785031d5.png)

The problems that reveal in the solution seem to be connected with the fact, that the structure with all currencies is hardcoded inside the golang code. For now I am analyzing this connection and think how it may be overcome. Thinking about replacing the first value in the structure from _ETH_ to the configurable value.
